### PR TITLE
Fix journal API

### DIFF
--- a/openedx/features/genplus_features/genplus/api/v1/serializers.py
+++ b/openedx/features/genplus_features/genplus/api/v1/serializers.py
@@ -50,10 +50,14 @@ class UserInfoSerializer(serializers.ModelSerializer):
                   'first_name', 'last_name', 'email', 'school')
 
 class TeacherSerializer(serializers.ModelSerializer):
+    user_id = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
     class Meta:
         model = Teacher
-        fields = ('id', 'name', 'profile_image')
+        fields = ('id', 'user_id', 'name', 'profile_image')
+    
+    def get_user_id(self, obj):
+        return obj.gen_user.user.id
 
     def get_name(self, obj):
         profile = UserProfile.objects.filter(user=obj.gen_user.user).first()

--- a/openedx/features/genplus_features/genplus/api/v1/views.py
+++ b/openedx/features/genplus_features/genplus/api/v1/views.py
@@ -279,13 +279,13 @@ class JournalViewSet(GenzMixin, FlatMultipleModelMixin, viewsets.ModelViewSet):
             data['student'] = self.gen_user.student.id
             data['skill'] = request_data.get('skill')
         elif journal_type == JournalTypes.TEACHER_FEEDBACK:
-            data['student'] = self.request.query_params.get('student_id')
+            data['student'] = request_data.get('student_id')
             data['teacher'] = self.gen_user.teacher.id
 
         return data
 
-    def partial_update(self, request, *args, **kwargs):
-        journal_post = self.get_object()
+    def partial_update(self, request, pk=None, *args, **kwargs):
+        journal_post = get_object_or_404(JournalPost, pk=pk)
 
         if self.gen_user.is_student:
             success_message = SuccessMessages.STUDENT_POST_UPDATED


### PR DESCRIPTION
- Fixed journal's create (was not working for teacher feedback type) and update (was not able to get current journal object) endpoints
- Exposed user id in TeacherSerializer to be able to find out if a particular feedback was given by the current logged in teacher. So, that he/she can update it. And, not allow other teachers to update feedback if they are not the owners.