### PR TITLE
Add completion tracking enable/disable functionality for subsection

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1238,6 +1238,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
+            'is_completion_tracked': xblock.is_completion_tracked,
         })
 
         if xblock.category == 'sequential':

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -68,6 +68,7 @@ class CourseMetadata:
         'hide_after_due',
         'self_paced',
         'show_correctness',
+        'is_completion_tracked',
         'chrome',
         'default_tab',
         'highlights_enabled_for_messaging',

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -17,7 +17,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         AbstractEditor, BaseDateEditor,
         ReleaseDateEditor, DueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
-        AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor;
+        AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor, CompletionTrackingEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -909,6 +909,41 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    CompletionTrackingEditor = AbstractEditor.extend({
+        templateName: 'completion-tracking-editor',
+        className: 'edit-completion-tracking',
+
+        afterRender: function() {
+            AbstractEditor.prototype.afterRender.call(this);
+            this.setValue(this.model.get('is_completion_tracked'));
+        },
+
+        setValue: function(value) {
+            this.$('input[name=completion-tracking][value=' + value + ']').prop('checked', true);
+        },
+
+        currentValue: function() {
+            return this.$('input[name=completion-tracking]:checked').val();
+        },
+
+        hasChanges: function() {
+            return this.model.get('is_completion_tracked') !== this.currentValue();
+        },
+
+        getRequestData: function() {
+            if (this.hasChanges()) {
+                return {
+                    publish: 'republish',
+                    metadata: {
+                        is_completion_tracked: this.currentValue()
+                    }
+                };
+            } else {
+                return {};
+            }
+        }
+    });
+
     ShowCorrectnessEditor = AbstractEditor.extend({
         templateName: 'show-correctness-editor',
         className: 'edit-show-correctness',
@@ -1078,6 +1113,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
 
+                    advancedTab.editors.push(CompletionTrackingEditor);
                     if (options.enable_proctored_exams || options.enable_timed_exams) {
                         advancedTab.editors.push(TimedExaminationPreferenceEditor);
                     }

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'completion-tracking-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/completion-tracking-editor.underscore
+++ b/cms/templates/js/completion-tracking-editor.underscore
@@ -1,0 +1,21 @@
+<form>
+<h3 class="modal-section-title" id="completion_tracking_label"><%- gettext('Completion Tracking') %></h3>
+<div class="modal-section-content completion-tracking">
+    <div role="group" class="list-fields" aria-labelledby="completion_tracking_label">
+        <label class="label">
+            <input class="input input-radio" name="completion-tracking" type="radio" value="true"/>
+            <%- gettext('Enable') %>
+        </label>
+        <p class='field-message' id='enable_completion_tracking'>
+            <%- gettext('Learner progress for this subsection will tracked.') %>
+        </p>
+        <label class="label">
+            <input class="input input-radio" name="completion-tracking" type="radio" value="false"/>
+            <%- gettext('Disable') %>
+        </label>
+        <p class='field-message' id='disable_completion_tracking'>
+            <%- gettext('Learner progress for this subsection will not be tracked.') %>
+        </p>
+    </div>
+</div>
+</form>

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -56,6 +56,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
     SupportedFieldType('show_correctness'),
+    SupportedFieldType('is_completion_tracked'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),
     # 'student_view_multi_device'

--- a/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
+++ b/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
@@ -52,7 +52,7 @@ class BlocksAPITransformer(BlockStructureTransformer):
         transform method.
         """
         # collect basic xblock fields
-        block_structure.request_xblock_fields('graded', 'format', 'display_name', 'category', 'due', 'show_correctness')
+        block_structure.request_xblock_fields('graded', 'format', 'display_name', 'category', 'due', 'show_correctness', 'is_completion_tracked')
 
         # collect data from containing transformers
         StudentViewTransformer.collect(block_structure)

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -92,6 +92,11 @@ class LmsBlockMixin(XBlockMixin):
         default=False,
         scope=Scope.settings,
     )
+    is_completion_tracked = Boolean(
+        help=_("If true, problems completion will be tracked"),
+        default=True,
+        scope=Scope.settings,
+    )
     group_access = GroupAccessDict(
         help=_(
             "A dictionary that maps which groups can be shown this block. The keys "

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -115,6 +115,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'completion',
             'complete',
             'resume_block',
+            'is_completion_tracked',
         ],
         allow_start_dates_in_future=allow_start_dates_in_future,
     )

--- a/openedx/features/genplus_features/genplus_learning/utils.py
+++ b/openedx/features/genplus_features/genplus_learning/utils.py
@@ -228,6 +228,9 @@ def get_course_block_completion(course_block, include_block_children, block_id=N
             include_block_children,
             block_id
         )
+        if block.get('is_completion_tracked') == False:
+            child_completion['total_blocks'] = 0
+            child_completion['total_completed_blocks'] = 0
 
         completion['total_blocks'] += child_completion['total_blocks']
         completion['total_completed_blocks'] += child_completion['total_completed_blocks']


### PR DESCRIPTION
Description: This feature add enable and disable functionality for completion tracking on the subsection level in course structure

Dependency: We need to add `block_structure.invalidate_cache_on_publish` waffle switch in order to make this work.